### PR TITLE
Some changes and upgrades

### DIFF
--- a/wazuh-deploy.sh
+++ b/wazuh-deploy.sh
@@ -32,19 +32,6 @@ systemctl status wazuh-api
 service wazuh-api status
 sleep 5
 
-#Add filebeat
-curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
-echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-6.x.list
-apt-get update
-apt-get install filebeat -y
-curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/3.0/extensions/filebeat/filebeat.yml
-sed -i 's/ELASTIC_SERVER_IP/127.0.0.1/g' /etc/filebeat/filebeat.yml
-systemctl daemon-reload
-systemctl enable filebeat.service
-systemctl start filebeat.service
-systemctl status filebeat.service
-sleep 5
-
 #Install ELK
 #Java
 echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee /etc/apt/sources.list.d/webupd8team-java.list
@@ -60,7 +47,7 @@ curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
 echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-6.x.list
 apt-get update
 #Elasticsearch
-apt-get install elasticsearch=6.0.1 -y
+apt-get install elasticsearch=6.1.0 -y
 systemctl daemon-reload
 systemctl enable elasticsearch.service
 systemctl start elasticsearch.service
@@ -69,17 +56,16 @@ curl https://raw.githubusercontent.com/wazuh/wazuh/3.0/extensions/elasticsearch/
 curl https://raw.githubusercontent.com/wazuh/wazuh/3.0/extensions/elasticsearch/wazuh-elastic6-template-monitoring.json | curl -XPUT 'http://localhost:9200/_template/wazuh-agent' -H 'Content-Type: application/json' -d @-
 curl https://raw.githubusercontent.com/wazuh/wazuh/3.0/extensions/elasticsearch/alert_sample.json | curl -XPUT "http://localhost:9200/wazuh-alerts-3.x-"`date +%Y.%m.%d`"/wazuh/sample" -H 'Content-Type: application/json' -d @-
 #Logstash
-apt-get install logstash=6.0.1 -y
+apt-get install logstash=6.1.0 -y
 curl -so /etc/logstash/conf.d/01-wazuh.conf https://raw.githubusercontent.com/wazuh/wazuh/3.0/extensions/logstash/01-wazuh-local.conf
 usermod -a -G ossec logstash
-curl -so /etc/logstash/conf.d/01-wazuh.conf https://raw.githubusercontent.com/wazuh/wazuh/3.0/extensions/logstash/01-wazuh-remote.conf
 systemctl daemon-reload
 systemctl enable logstash.service
 systemctl start logstash.service
 sleep 5
 
 #Kibana
-apt-get install kibana=6.0.1 -y
+apt-get install kibana=6.1.0 -y
 /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp.zip
 sed -i '/#server.host: "localhost"/c\server.host: "0.0.0.0"' /etc/kibana/kibana.yml
 systemctl daemon-reload


### PR DESCRIPTION
 The last Wazuhapp version is for 6.1.0
 Filebeat is not necessary for a "local" installation.
 Only one logstash configuration file needs it in the "local" installation.